### PR TITLE
contextSet return original Request

### DIFF
--- a/context.go
+++ b/context.go
@@ -14,5 +14,7 @@ func contextSet(r *http.Request, key, val interface{}) *http.Request {
 		return r
 	}
 
-	return r.WithContext(context.WithValue(r.Context(), key, val))
+	r2 := r.WithContext(context.WithValue(r.Context(), key, val))
+	*r = *r2
+	return r
 }

--- a/context_test.go
+++ b/context_test.go
@@ -3,6 +3,7 @@ package mux
 import (
 	"context"
 	"net/http"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -27,4 +28,25 @@ func TestNativeContextMiddleware(t *testing.T) {
 	rec := NewRecorder()
 	req := newRequest("GET", "/path/bar")
 	r.ServeHTTP(rec, req)
+}
+
+func TestContextSetGet(t *testing.T) {
+	tests := []struct {
+		key   interface{}
+		value interface{}
+	}{
+		{1, 2},
+		{"test", 42},
+	}
+
+	req := newRequest("GET", "/path/bar")
+	for _, test := range tests {
+		contextSet(req, test.key, test.value)
+	}
+	for _, test := range tests {
+		value := contextGet(req, test.key)
+		if !reflect.DeepEqual(value, test.value) {
+			t.Errorf(`Expected %+v got %+v`, test.value, value)
+		}
+	}
 }


### PR DESCRIPTION
`contextSet` return the original *http.Request.