### PR TITLE
support route disable enable

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -137,6 +137,9 @@ func copyRouteRegexp(r *routeRegexp) *routeRegexp {
 // field of the match argument.
 func (r *Router) Match(req *http.Request, match *RouteMatch) bool {
 	for _, route := range r.routes {
+		if route.disable {
+			continue
+		}
 		if route.Match(req, match) {
 			// Build middleware chain if no error was found
 			if match.MatchErr == nil {

--- a/route.go
+++ b/route.go
@@ -27,6 +27,9 @@ type Route struct {
 	// "global" reference to all named routes
 	namedRoutes map[string]*Route
 
+	// If true, this route will not be matches: until it is set false
+	disable bool
+
 	// config possibly passed in from `Router`
 	routeConf
 }
@@ -35,6 +38,21 @@ type Route struct {
 // Router.SkipClean.
 func (r *Route) SkipClean() bool {
 	return r.skipClean
+}
+
+// Disable set Route.disable to true, so can skip this route while do Match
+func (r *Route) Disable() {
+	r.disable = true
+}
+
+// IsDisable check whether route is already disabled
+func (r *Route) IsDisable() bool {
+	return r.disable == true
+}
+
+// Enable set Route.disable to false, Match will check this route
+func (r *Route) Enable() {
+	r.disable = false
 }
 
 // Match matches the route against the request.


### PR DESCRIPTION
- add field `Route.disable` to indicate whether the route should be skip in match;
- add method `Route.Disable`  set `Route.disable` to `true`; 
- add method `Route.Enable` set `Route.disable` to `false`;